### PR TITLE
Ported @steveklett's governance changes for allowing parameter overrides

### DIFF
--- a/governance.ts
+++ b/governance.ts
@@ -53,10 +53,10 @@ export function governanceRemains(startTime = Date.now(), minutes = 45, units = 
  * ( so it can be invoked by takeWhile() as well)
  *
  */
-export function rescheduleIfNeeded(governancePredicate: () => boolean, params?: object, paramsCallback?: () => object) {
+export function rescheduleIfNeeded(governancePredicate: () => boolean, params?: object, paramsCallback?: (params?: object) => object) {
 	return () => {
 		const governanceRemains = governancePredicate();
-		const effectiveParams = paramsCallback ? paramsCallback() : params;
+		const effectiveParams = paramsCallback ? paramsCallback(params) : params;
 
 		if (!governanceRemains) {
 			const taskId = task.create({

--- a/test/governance.test.ts
+++ b/test/governance.test.ts
@@ -96,7 +96,32 @@ describe('rescheduling', () => {
 		const sut = rescheduleIfNeeded( alwaysFalse, undefined, () => makeScriptParams() )
 		expect(sut()).toEqual(false)
 		// task.create() is called with our script params
-		expect(mocktask.create.mock.calls[0][0]).toEqual( expect.objectContaining({params: scriptParams }) )
+		expect(JSON.stringify(mocktask.create.mock.calls[0][0].params)).toEqual( JSON.stringify(scriptParams) )
+	});
+
+	test('passes params to callback script when rescheduling (supersedes params:object parameter)', function () {
+		const alwaysFalse = () => false
+		let scriptParams = { foo: 'bar' }
+		const makeScriptParams = (params) => {
+			return params;
+		}
+		const sut = rescheduleIfNeeded( alwaysFalse, undefined, () => makeScriptParams(scriptParams) )
+		expect(sut()).toEqual(false)
+		// task.create() is called with our script params
+		expect(JSON.stringify(mocktask.create.mock.calls[0][0].params)).toEqual( JSON.stringify(scriptParams) )
+	});
+
+	test('passes params to callback script and receives modified params back while rescheduling (supersedes params:object parameter)', function () {
+		const alwaysFalse = () => false
+		let scriptParams = { foo: 'bar' }
+		const makeScriptParams = (params) => {
+			params.foo = 'baz';
+			return params;
+		}
+		const sut = rescheduleIfNeeded( alwaysFalse, undefined, () => makeScriptParams(scriptParams) )
+		expect(sut()).toEqual(false)
+		// task.create() is called with our script params
+		expect(JSON.stringify(mocktask.create.mock.calls[0][0].params)).toEqual( JSON.stringify({ foo: 'baz' }) )
 	});
 });
 


### PR DESCRIPTION
Governance changes to allow overriding the new task parameters while rescheduling. 

https://github.com/steveklett/netsuite-fasttrack-toolkit-ss2/commit/e0925a702d6b11060153796f31f3363175dcd226
https://github.com/steveklett/netsuite-fasttrack-toolkit-ss2/commit/ebba475ad7cb533a06f41211f80efacaae47414c#diff-82b7106a337fb4c2a5e2e3b88212ca26c9ec2aca4f7c4a091d961ce6a5e73617

Once the SDF project is setup we need to add a functional test around this. I'd recommend a simple scheduled script with a parameter default value of 1,2. Process 1, and then force a reschedule with just 2.