### PR TITLE
Fix import path for NetsuiteCurrentRecord type

### DIFF
--- a/DataAccess/FieldDescriptors/Sublist/SubRecordDescriptor.ts
+++ b/DataAccess/FieldDescriptors/Sublist/SubRecordDescriptor.ts
@@ -5,7 +5,7 @@
 * See LICENSE file for additional information.
 */
 
-import type { NetsuiteCurrentRecord } from "DataAccess/Record";
+import type { NetsuiteCurrentRecord } from "../../Record";
 import type * as record from 'N/record';
 import type { SublistLine } from '../../Sublist';
 


### PR DESCRIPTION
Looks like this got missed when moving the sublist descriptors. Found while setting up the integration project.

This doesn't error out on the repository itself since DataAccess is a separate include path.