### PR TITLE
Updated DataAccess/Record.ts to better handle null or invalid record IDs.

### DIFF
--- a/DataAccess/Record.ts
+++ b/DataAccess/Record.ts
@@ -78,9 +78,9 @@ export abstract class NetsuiteCurrentRecord {
 		// pull the 'static' recordType from the derived class and remove the need for derived classes to
 		// define a constructor to pass the record type to super()
 		const type = Object.getPrototypeOf(this).constructor.recordType();
-        let id: number | null | string | unknown;
+		let id: number | null | string | unknown;
 
-        if (!rec) {
+		if (!rec) {
 			// falsey values (e.g. invalid id 0, null, undefined, etc.) implies creating a new record
 			log.debug('creating new record', `type:${type}  isDyanamic:${isDynamic} defaultValues:${defaultValues}`);
 			this.makeRecordProp(record.create({ type: type, isDynamic: isDynamic, defaultValues: defaultValues }));
@@ -88,12 +88,12 @@ export abstract class NetsuiteCurrentRecord {
 			log.debug('using existing record', `type:${rec.type}, id:${rec.id}`);
 			this.makeRecordProp(rec);
 
-            id = rec.id;
-            if (Number.isNaN(Number(id)) || id === undefined || id === null) {
-                throw new Error(`Unable to load record with id: ${id}`);
-            }
+			id = rec.id;
+			if (Number.isNaN(Number(id)) || id === undefined || id === null) {
+				throw new Error(`Unable to load record with id: ${id}`);
+			}
 
-            this._id = Number(id);
+			this._id = Number(id);
 		}
 		// allow
 		else if (typeof rec === 'number' || +rec) {
@@ -107,12 +107,12 @@ export abstract class NetsuiteCurrentRecord {
 				}),
 			);
 
-            id = this.nsrecord?.id;
-            if (Number.isNaN(Number(id)) || id === undefined || id === null) {
-                throw new Error(`Unable to load record with id: ${id}`);
-            }
+			id = this.nsrecord?.id;
+			if (Number.isNaN(Number(id)) || id === undefined || id === null) {
+				throw new Error(`Unable to load record with id: ${id}`);
+			}
 
-            this._id = Number(id);
+			this._id = Number(id);
 		} else
 			throw new Error(`invalid value for argument "rec": ${rec}. 
       Must be one of: null/undefined, an internal id, or an existing record`);

--- a/DataAccess/Record.ts
+++ b/DataAccess/Record.ts
@@ -78,14 +78,22 @@ export abstract class NetsuiteCurrentRecord {
 		// pull the 'static' recordType from the derived class and remove the need for derived classes to
 		// define a constructor to pass the record type to super()
 		const type = Object.getPrototypeOf(this).constructor.recordType();
-		if (!rec) {
+        let id: number | null | string | unknown;
+
+        if (!rec) {
 			// falsey values (e.g. invalid id 0, null, undefined, etc.) implies creating a new record
 			log.debug('creating new record', `type:${type}  isDyanamic:${isDynamic} defaultValues:${defaultValues}`);
 			this.makeRecordProp(record.create({ type: type, isDynamic: isDynamic, defaultValues: defaultValues }));
 		} else if (typeof rec === 'object') {
 			log.debug('using existing record', `type:${rec.type}, id:${rec.id}`);
 			this.makeRecordProp(rec);
-			this._id = rec?.id;
+
+            id = rec.id;
+            if (Number.isNaN(Number(id)) || id === undefined || id === null) {
+                throw new Error(`Unable to load record with id: ${id}`);
+            }
+
+            this._id = Number(id);
 		}
 		// allow
 		else if (typeof rec === 'number' || +rec) {
@@ -98,7 +106,13 @@ export abstract class NetsuiteCurrentRecord {
 					defaultValues: defaultValues,
 				}),
 			);
-			this._id = this.nsrecord?.id;
+
+            id = this.nsrecord?.id;
+            if (Number.isNaN(Number(id)) || id === undefined || id === null) {
+                throw new Error(`Unable to load record with id: ${id}`);
+            }
+
+            this._id = Number(id);
 		} else
 			throw new Error(`invalid value for argument "rec": ${rec}. 
       Must be one of: null/undefined, an internal id, or an existing record`);

--- a/__mocks__/N/record.ts
+++ b/__mocks__/N/record.ts
@@ -7,6 +7,7 @@
 
 export const create = jest
 	.fn(function (config) {
+        this.id = config.id;
 		this.isDynamic = config.isDynamic;
 		this.type = config.type;
 		return this;

--- a/__mocks__/N/record.ts
+++ b/__mocks__/N/record.ts
@@ -7,7 +7,7 @@
 
 export const create = jest
 	.fn(function (config) {
-        this.id = config.id;
+		this.id = config.id;
 		this.isDynamic = config.isDynamic;
 		this.type = config.type;
 		return this;

--- a/test/nsdal.test.ts
+++ b/test/nsdal.test.ts
@@ -52,7 +52,7 @@ describe('instantiation', () => {
 	});
 
 	test('with record object', () => {
-		const c = new cust.CustomerBase(mockrecord.create({ type: 'foo' }));
+		const c = new cust.CustomerBase(mockrecord.create({ id: 123, type: 'foo' }));
 
 		expect(c).toBeTruthy();
 		// should not call load if we insantiate with an existing object
@@ -64,7 +64,7 @@ describe('instantiation', () => {
 	});
 
 	test('TransactionBase from existing record', () => {
-		const t = new TransactionBase(mockrecord.create({ type: 'foo' }));
+		const t = new TransactionBase(mockrecord.create({ id: 123, type: 'foo' }));
 		expect(t).toBeTruthy();
 		expect(t).toHaveProperty('otherrefnum');
 		// should not call load since we already have a record
@@ -158,7 +158,7 @@ describe('serialization', () => {
 		expect(serializedjson).toContain('accountnumber');
 		expect(serializedjson).toContain('email');
 		// id should always be there.
-		expect(serializedjson).toMatch(/"id".?:.?"123"/);
+		expect(serializedjson).toMatch(/"id".?:.?123/);
 		// JSON.stringify does not serialize undefined fields
 		expect(serializedjson).not.toContain('externalid');
 	});

--- a/test/record.test.ts
+++ b/test/record.test.ts
@@ -12,7 +12,7 @@ import { type Sublist, SublistFieldType, SublistLine } from '../DataAccess/Subli
 
 describe('Record base tests', () => {
 	test('getText() on field', () => {
-		const fakeRec = record.create({ type: 'fake' });
+		const fakeRec = record.create({ id: 123, type: 'fake' });
 		record.getText.mockReturnValue('some text');
 		record.getValue.mockReturnValue(123);
 
@@ -38,7 +38,7 @@ describe('Record base tests', () => {
 	});
 
 	test('getField() success', () => {
-		const fakeRec = record.create({ type: 'fake' });
+		const fakeRec = record.create({ id: 123, type: 'fake' });
 		record.getField.mockReturnValue({});
 
 		// this was a bug - a field with any of the characters in 'Text' got ALL such characters trimmed
@@ -76,7 +76,7 @@ describe('Record base tests', () => {
 			@FieldType.sublist(FakeSublist)
 			footSublist: Sublist<FakeSublist>;
 		}
-		const fakeRec = record.create({ type: 'fake' });
+		const fakeRec = record.create({ id: 123, type: 'fake' });
 		fakeRec.getLineCount.mockReturnValue(1);
 
 		const sut = new A(fakeRec);
@@ -102,7 +102,7 @@ describe('Record base tests', () => {
 	 */
 	test('constructors', () => {
 		// a strongly typed NS record
-		const fakeRec: nsRecord.Record = record.create({ type: 'fake' });
+		const fakeRec: nsRecord.Record = record.create({ id: 123, type: 'fake' });
 
 		// an NSDAL record type
 		class A extends NetsuiteRecord {}


### PR DESCRIPTION
I was prepping to author the new release, and while building I was getting the following error. Not sure if a TS update triggered something. I've been able to build the project as part of the SDF project.

```
DataAccess/Record.ts:88:4 - error TS2322: Type 'number | null' is not assignable to type 'number'.
  Type 'null' is not assignable to type 'number'.

88    this._id = rec?.id;
      ~~~~~~~~

DataAccess/Record.ts:101:4 - error TS2322: Type 'number | null' is not assignable to type 'number'.
  Type 'null' is not assignable to type 'number'.

101    this._id = this.nsrecord?.id;
       ~~~~~~~~


Found 2 errors in the same file, starting at: DataAccess/Record.ts:88
```